### PR TITLE
feat: add prediction and ground truth pose visualization

### DIFF
--- a/athleticspose/visualize.py
+++ b/athleticspose/visualize.py
@@ -1,0 +1,161 @@
+"""Visualization functions."""
+
+from pathlib import Path
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import animation
+from mpl_toolkits.mplot3d import art3d
+
+from athleticspose.statics.bones import h36m_bones
+
+
+def align_poses(predicted: np.ndarray, target: np.ndarray) -> np.ndarray:
+    """Align predicted pose to target pose using Procrustes Analysis.
+
+    Args:
+        predicted (np.ndarray): Predicted keypoints. shape: (T, J, 3)
+        target (np.ndarray): Target keypoints. shape: (T, J, 3)
+
+    Returns:
+        np.ndarray: Aligned predicted keypoints.
+
+    """
+    mu_x = np.mean(target, axis=1, keepdims=True)
+    mu_y = np.mean(predicted, axis=1, keepdims=True)
+
+    x0 = target - mu_x
+    y0 = predicted - mu_y
+
+    norm_x = np.sqrt(np.sum(x0**2, axis=(1, 2), keepdims=True))
+    norm_y = np.sqrt(np.sum(y0**2, axis=(1, 2), keepdims=True))
+
+    x0 /= norm_x
+    y0 /= norm_y
+
+    h = np.matmul(x0.transpose(0, 2, 1), y0)
+    u, s, v_t = np.linalg.svd(h)
+    v = v_t.transpose(0, 2, 1)
+    r = np.matmul(v, u.transpose(0, 2, 1))
+
+    # Avoid improper rotations (reflections)
+    sign_det_r = np.sign(np.expand_dims(np.linalg.det(r), axis=1))
+    v[:, :, -1] *= sign_det_r
+    s[:, -1] *= sign_det_r.flatten()
+    r = np.matmul(v, u.transpose(0, 2, 1))  # Rotation
+
+    tr = np.expand_dims(np.sum(s, axis=1, keepdims=True), axis=2)
+    a = tr * norm_x / norm_y  # Scale
+    t = mu_x - a * np.matmul(mu_y, r)  # Translation
+
+    # Apply rigid transformation
+    predicted_aligned = a * np.matmul(predicted, r) + t
+    return predicted_aligned
+
+
+def set_lines(
+    x: np.ndarray, y: np.ndarray, z: np.ndarray, bones: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Set lines for 3D visualization.
+
+    Args:
+        x (np.ndarray): X coordinates.
+        y (np.ndarray): Y coordinates.
+        z (np.ndarray): Z coordinates.
+        bones (np.ndarray): Bone connections.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray, np.ndarray]: Line coordinates for X, Y, Z.
+
+    """
+    line_x, line_y, line_z = [], [], []
+    for bone in bones:
+        line_x.append([x[bone[0]], x[bone[1]]])
+        line_y.append([y[bone[0]], y[bone[1]]])
+        line_z.append([z[bone[0]], z[bone[1]]])
+    return np.array(line_x), np.array(line_y), np.array(line_z)
+
+
+def visualize_pose_comparison(
+    pred: np.ndarray,
+    gt: np.ndarray,
+    output_path: str,
+    title: Optional[str] = None,
+    is_aligned: bool = False,
+) -> None:
+    """Visualize prediction and ground truth in 3D.
+
+    Args:
+        pred: Prediction. shape: (T, J, 3)
+        gt: Ground truth 3D pose. shape: (T, J, 3)
+        output_path: Output path for visualization
+        title: Optional title for the plot
+        is_aligned: Whether the prediction is aligned to ground truth
+
+    """
+    fig = plt.figure(figsize=(10, 10))
+    fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
+    ax = fig.add_subplot(111, projection="3d")
+
+    def draw_skeleton(ax: plt.Axes, kpts3d_pred: np.ndarray, kpts3d_gt: np.ndarray) -> None:
+        """Draw skeleton."""
+        ax.clear()
+        if title is not None:
+            ax.set_title(title)
+        ax.view_init(elev=100, azim=90)
+        ax.set_xlim(-1000, 1000)
+        ax.set_ylim(-1000, 1000)
+        ax.set_zlim(-1000, 1000)
+        ax.set_xlabel("X")
+        ax.set_ylabel("Y")
+        ax.set_zlabel("Z")
+        ax.set_xticklabels([])
+        ax.set_yticklabels([])
+        ax.set_zticklabels([])
+
+        # Draw ground truth (black)
+        x0_gt, y0_gt, z0_gt = kpts3d_gt[:, 0], kpts3d_gt[:, 1], kpts3d_gt[:, 2]
+        ax.plot(x0_gt, y0_gt, z0_gt, "k.", label="GT")
+        x_bone_gt, y_bone_gt, z_bone_gt = set_lines(x0_gt, y0_gt, z0_gt, h36m_bones)
+        for x, y, z in zip(x_bone_gt, y_bone_gt, z_bone_gt, strict=False):
+            line = art3d.Line3D(x, y, z, color="black")
+            ax.add_line(line)
+
+        # Draw prediction (red)
+        x0_pred, y0_pred, z0_pred = kpts3d_pred[:, 0], kpts3d_pred[:, 1], kpts3d_pred[:, 2]
+        ax.plot(x0_pred, y0_pred, z0_pred, "r.", label="Pred")
+        x_bone_pred, y_bone_pred, z_bone_pred = set_lines(x0_pred, y0_pred, z0_pred, h36m_bones)
+        for x, y, z in zip(x_bone_pred, y_bone_pred, z_bone_pred, strict=False):
+            line = art3d.Line3D(x, y, z, color="red")
+            ax.add_line(line)
+
+        ax.invert_xaxis()
+        ax.invert_zaxis()
+
+    def update_frame(fc: int) -> None:
+        """Update frame."""
+        draw_skeleton(ax, pred[fc], gt[fc])
+
+    ani = animation.FuncAnimation(
+        fig,
+        update_frame,
+        frames=pred.shape[0],
+        interval=30,
+        repeat=False,
+    )
+
+    # Ensure output directory exists
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Add suffix based on alignment status
+    suffix = "_aligned" if is_aligned else "_raw"
+    output_path = output_path.parent / f"{output_path.stem}{suffix}"
+
+    # Save as MP4
+    ani.save(f"{output_path}.mp4", fps=30)
+
+    # Save as GIF with high quality
+    ani.save(f"{output_path}.gif", fps=30, writer="pillow", dpi=200)
+    plt.close()

--- a/athleticspose/visualize.py
+++ b/athleticspose/visualize.py
@@ -116,18 +116,18 @@ def visualize_pose_comparison(
 
         # Draw ground truth (black)
         x0_gt, y0_gt, z0_gt = kpts3d_gt[:, 0], kpts3d_gt[:, 1], kpts3d_gt[:, 2]
-        ax.plot(x0_gt, y0_gt, z0_gt, "k.", label="GT")
+        ax.plot(x0_gt, y0_gt, z0_gt, "k.", label="GT", markersize=18)
         x_bone_gt, y_bone_gt, z_bone_gt = set_lines(x0_gt, y0_gt, z0_gt, h36m_bones)
         for x, y, z in zip(x_bone_gt, y_bone_gt, z_bone_gt, strict=False):
-            line = art3d.Line3D(x, y, z, color="black")
+            line = art3d.Line3D(x, y, z, color="black", linewidth=4.5)
             ax.add_line(line)
 
-        # Draw prediction (red)
+        # Draw prediction (red) with transparency
         x0_pred, y0_pred, z0_pred = kpts3d_pred[:, 0], kpts3d_pred[:, 1], kpts3d_pred[:, 2]
-        ax.plot(x0_pred, y0_pred, z0_pred, "r.", label="Pred")
+        ax.plot(x0_pred, y0_pred, z0_pred, "r.", label="Pred", markersize=18, alpha=0.8)
         x_bone_pred, y_bone_pred, z_bone_pred = set_lines(x0_pred, y0_pred, z0_pred, h36m_bones)
         for x, y, z in zip(x_bone_pred, y_bone_pred, z_bone_pred, strict=False):
-            line = art3d.Line3D(x, y, z, color="red")
+            line = art3d.Line3D(x, y, z, color="red", linewidth=4.5, alpha=0.8)
             ax.add_line(line)
 
         ax.invert_xaxis()

--- a/scripts/evaluate_single_pose.py
+++ b/scripts/evaluate_single_pose.py
@@ -10,6 +10,7 @@ import torch
 from athleticspose.datasets.ap_dataset import read_pkl
 from athleticspose.loss import calc_mpjpe, p_mpjpe
 from athleticspose.plmodules.linghtning_module import LightningPose3D
+from athleticspose.visualize import align_poses, visualize_pose_comparison
 
 
 def calculate_metrics(
@@ -66,6 +67,17 @@ def main():
         default="work_dir/20250302_110906/best.ckpt",
         help="Path to model checkpoint",
     )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="data/output",
+        help="Directory to save visualization results",
+    )
+    parser.add_argument(
+        "--visualize",
+        action="store_true",
+        help="If set, visualize the prediction and ground truth",
+    )
     args = parser.parse_args()
 
     # Set device
@@ -105,6 +117,44 @@ def main():
     print(f"Action: {action}")
     print(f"MPJPE: {mpjpe:.2f} mm")
     print(f"PA-MPJPE: {pa_mpjpe:.2f} mm")
+
+    # Visualize if requested
+    if args.visualize:
+        # Convert prediction and label to numpy and denormalize
+        pred = pred.cpu().numpy()
+        label3d = label3d.cpu().numpy()
+
+        pred_denom = np.zeros_like(pred)
+        label3d_denom = np.zeros_like(label3d)
+        for i in range(pred.shape[0]):
+            pred_denom[i, :, :, :] = pred[i] * norm_scale[i]
+            label3d_denom[i, :, :, :] = label3d[i] * norm_scale[i]
+        pred_denom = pred_denom / p2mm.cpu().numpy()[:, :, None, None]
+        label3d_denom = label3d_denom / p2mm.cpu().numpy()[:, :, None, None]
+
+        # Prepare output path
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(exist_ok=True, parents=True)
+        output_base = output_dir / Path(args.input_file).stem
+
+        # Visualize raw poses
+        visualize_pose_comparison(
+            pred_denom[0],  # Remove batch dimension
+            label3d_denom[0],  # Remove batch dimension
+            str(output_base),
+            title=f"Action: {action}",
+            is_aligned=False,
+        )
+
+        # Align prediction to ground truth and visualize
+        pred_aligned = align_poses(pred_denom[0], label3d_denom[0])
+        visualize_pose_comparison(
+            pred_aligned,  # Already batch dimension removed
+            label3d_denom[0],  # Remove batch dimension
+            str(output_base),
+            title=f"Action: {action}",
+            is_aligned=True,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 変更内容
- 推論結果とground-truthの3D可視化機能を追加
  - アライメントの有無で2種類の可視化結果を生成
  - 推論結果は赤色、ground-truthは黒色で表示
  - 推論結果をground-truthの上に描画
- mp4およびgif形式で保存する機能を追加
  - GIFは高解像度で出力
  - 出力ディレクトリをコマンドライン引数で指定可能
- 軸の見た目を改善
  - 数字のラベルを非表示に
  - X, Y, Z軸のラベルは表示

## 変更の背景・目的
- 推論結果とground-truthを視覚的に比較できるようにするため
- アライメント前後の差異を確認できるようにするため
- 可視化結果を動画として保存し、共有やプレゼンテーションで使用可能にするため

## テスト結果
- [x] 動作確認済み
  - アライメントの有無で2種類の可視化結果が生成されることを確認
  - 描画順序とカラーリングが意図通りであることを確認
  - mp4とgifの両方が正しく出力されることを確認